### PR TITLE
Adding classical format and classical genre detection

### DIFF
--- a/audiorename/args.py
+++ b/audiorename/args.py
@@ -102,7 +102,7 @@ class ArgsDefault():
     dry_run = False
     enrich_metadata = False
     extension = 'mp3,m4a,flac,wma'
-    genre_classical = 'classical,'
+    genre_classical = ','
     field_skip = False
     format = False
     job_info = False

--- a/audiorename/args.py
+++ b/audiorename/args.py
@@ -102,6 +102,7 @@ class ArgsDefault():
     dry_run = False
     enrich_metadata = False
     extension = 'mp3,m4a,flac,wma'
+    genre_classical = 'classical,'
     field_skip = False
     format = False
     job_info = False

--- a/audiorename/args.py
+++ b/audiorename/args.py
@@ -15,7 +15,6 @@ fields = {
         'description': '“album” without ” (Disc X)”.',
         'category': 'ordinary',
     },
-    'ar_initial_album': {
         'description': 'First character in lowercase of “ar_combined_album”.',
         'category': 'ordinary',
     },
@@ -111,6 +110,7 @@ class ArgsDefault():
     no_rename = False
     one_line = False
     remap_classical = False
+    format_classical = False
     shell_friendly = False
     soundtrack = False
     source = u'.'

--- a/audiorename/args.py
+++ b/audiorename/args.py
@@ -15,10 +15,11 @@ fields = {
         'description': '“album” without ” (Disc X)”.',
         'category': 'ordinary',
     },
+    'ar_initial_album': {
         'description': 'First character in lowercase of “ar_combined_album”.',
         'category': 'ordinary',
     },
-    # artist2
+    # artist
     'ar_initial_artist': {
         'description': 'First character in lowercase of '
                        '“ar_combined_artist_sort”',

--- a/audiorename/args.py
+++ b/audiorename/args.py
@@ -18,7 +18,7 @@ fields = {
         'description': 'First character in lowercase of “ar_combined_album”.',
         'category': 'ordinary',
     },
-    # artist
+    # artist2
     'ar_initial_artist': {
         'description': 'First character in lowercase of '
                        '“ar_combined_artist_sort”',

--- a/audiorename/args.py
+++ b/audiorename/args.py
@@ -328,7 +328,13 @@ def parse_args(argv):
         help='Extensions to rename',
         default='mp3,m4a,flac,wma'
     )
-
+    
+    # extension
+    filters.add_argument(
+        '--genre-classical',
+        help='List of Genres to be classical',
+        default='classical,'
+    )
 ###############################################################################
 # formats
 ###############################################################################
@@ -389,7 +395,15 @@ def parse_args(argv):
         and functions to build the format string.',
         default=False
     )
-
+    
+    # classical
+    format_strings.add_argument(
+        '--format-classical',
+        metavar='FORMAT_STRING',
+        help='Format string for classical audio file. Use metadata fields \
+        and functions to build the format string.',
+        default=False
+    )
 ###############################################################################
 # output
 ###############################################################################

--- a/audiorename/audiofile.py
+++ b/audiorename/audiofile.py
@@ -347,13 +347,14 @@ def do_job_on_audiofile(source, job=None):
             job.metadata_actions.enrich_metadata,
             job.metadata_actions.remap_classical
         )
-    elif source.meta.genre is not None and getattr(source.meta,"genre","").lower() in job.filter.genre_classical:
-        action.metadata(
-            source,
-            job.metadata_actions.enrich_metadata,
-            True
-        )
-        print(job.filter.genre_classical)
+    if source.meta.genre is not None and getattr(source.meta,"genre","").lower() in job.filter.genre_classical:
+        
+        if not job.metadata_actions.remap_classical:
+            action.metadata(
+                source,
+                job.metadata_actions.enrich_metadata,
+                True
+            )
         job.format.default = job.format.classical
         job.format.compilation = job.format.classical
         job.format.soundtrack = job.format.classical

--- a/audiorename/audiofile.py
+++ b/audiorename/audiofile.py
@@ -349,11 +349,10 @@ def do_job_on_audiofile(source, job=None):
         )
     if source.meta.genre is not None and getattr(source.meta,"genre","").lower() in job.filter.genre_classical:
         
-        if not (job.metadata_actions.remap_classical or \
-            job.metadata_actions.enrich_metadata):
+        if not (job.metadata_actions.remap_classical):
             action.metadata(
                 source,
-                job.metadata_actions.enrich_metadata,
+                False,
                 True
             )
         job.format.default = job.format.classical

--- a/audiorename/audiofile.py
+++ b/audiorename/audiofile.py
@@ -347,7 +347,7 @@ def do_job_on_audiofile(source, job=None):
             job.metadata_actions.enrich_metadata,
             job.metadata_actions.remap_classical
         )
-    elif source.meta.genre in job.filter.genre_classical.split(","):
+    elif source.meta.genre in job.filter.genreclassical.split(","):
         action.metadata(
             source,
             job.metadata_actions.enrich_metadata,

--- a/audiorename/audiofile.py
+++ b/audiorename/audiofile.py
@@ -347,7 +347,7 @@ def do_job_on_audiofile(source, job=None):
             job.metadata_actions.enrich_metadata,
             job.metadata_actions.remap_classical
         )
-    elif source.meta.genre.lower() in job.filter.genre_classical:
+    elif getattr(source.meta,"genre","").lower() in job.filter.genre_classical:
         action.metadata(
             source,
             job.metadata_actions.enrich_metadata,

--- a/audiorename/audiofile.py
+++ b/audiorename/audiofile.py
@@ -319,6 +319,8 @@ def do_job_on_audiofile(source, job=None):
         return
 
     if job.output.debug:
+        return
+        # following line throws errors... maybe meta fields is not correct set?
         phrydy.doc.print_debug(
             source.abspath,
             Meta,

--- a/audiorename/audiofile.py
+++ b/audiorename/audiofile.py
@@ -349,7 +349,8 @@ def do_job_on_audiofile(source, job=None):
         )
     if source.meta.genre is not None and getattr(source.meta,"genre","").lower() in job.filter.genre_classical:
         
-        if not job.metadata_actions.remap_classical:
+        if not (job.metadata_actions.remap_classical or \
+            job.metadata_actions.enrich_metadata):
             action.metadata(
                 source,
                 job.metadata_actions.enrich_metadata,

--- a/audiorename/audiofile.py
+++ b/audiorename/audiofile.py
@@ -341,6 +341,7 @@ def do_job_on_audiofile(source, job=None):
     ##
     
     if source.meta.genre in ["Classical","Classical Instrumental","Classical Ballet","Classical Piano","Klassische Musik","Piano","Klavier"]:
+        print(type(job.metadata_actions))
         job.metadata_actions=job.metadata_actions._replace(remap_classical=True)
 
     if job.metadata_actions.remap_classical or \

--- a/audiorename/audiofile.py
+++ b/audiorename/audiofile.py
@@ -162,8 +162,9 @@ def best_format(source, target, job):
         }
 
         types = {}
-        types[ranking[source.type]] = 'source'
-        types[ranking[target.type]] = 'target'
+        
+        types[ranking[source.type] if source.type in ranking else 0] = 'source'
+        types[ranking[target.type] if target.type in ranking else 0] = 'target'
         best = get_highest(types)
         job.msg.best_format(best, 'type', source, target)
         return best

--- a/audiorename/audiofile.py
+++ b/audiorename/audiofile.py
@@ -341,7 +341,7 @@ def do_job_on_audiofile(source, job=None):
     ##
     
     if source.meta.genre in ["Classical","Classical Instrumental","Classical Ballet","Classical Piano","Klassische Musik","Piano","Klavier"]:
-        job.metadata_actions._replace(remap_classical=True)
+        job.metadata_actions=job.metadata_actions._replace(remap_classical=True)
 
     if job.metadata_actions.remap_classical or \
             job.metadata_actions.enrich_metadata:

--- a/audiorename/audiofile.py
+++ b/audiorename/audiofile.py
@@ -347,30 +347,15 @@ def do_job_on_audiofile(source, job=None):
             job.metadata_actions.enrich_metadata,
             job.metadata_actions.remap_classical
         )
-    elif source.meta.genre in ["Classical","Classical Instrumental","Classical Ballet","Classical Piano","Klassische Musik","Piano","Klavier"]:
+    elif source.meta.genre in job.filter.genre_classical:
         action.metadata(
             source,
             job.metadata_actions.enrich_metadata,
             True
         )
-        job.format.default = '$ar_initial_composer/$ar_combined_composer/' \
-                '%shorten{$ar_combined_work_top,48}' \
-                '_[%shorten{$ar_classical_performer,32}]/' \
-                '${ar_combined_disctrack}_%shorten{$ar_classical_title,64}_' \
-                '%shorten{$acoustid_id,8}'
-
-        job.format.compilation = '$ar_initial_composer/$ar_combined_composer/' \
-                '%shorten{$ar_combined_work_top,48}' \
-                '_[%shorten{$ar_classical_performer,32}]/' \
-                '${ar_combined_disctrack}_%shorten{$ar_classical_title,64}_' \
-                '%shorten{$acoustid_id,8}'
-
-        job.format.soundtrack = '$ar_initial_composer/$ar_combined_composer/' \
-                '%shorten{$ar_combined_work_top,48}' \
-                '_[%shorten{$ar_classical_performer,32}]/' \
-                '${ar_combined_disctrack}_%shorten{$ar_classical_title,64}_' \
-                '%shorten{$acoustid_id,8}'
-
+        job.format.default = job.format.classical
+        job.format.compilation = job.format.classical
+        job.format.soundtrack = job.format.classical
     ##
     # Rename action
     ##

--- a/audiorename/audiofile.py
+++ b/audiorename/audiofile.py
@@ -347,12 +347,13 @@ def do_job_on_audiofile(source, job=None):
             job.metadata_actions.enrich_metadata,
             job.metadata_actions.remap_classical
         )
-    elif source.meta.genre in job.filter.genre_classical:
+    elif source.meta.genre.lower() in job.filter.genre_classical:
         action.metadata(
             source,
             job.metadata_actions.enrich_metadata,
             True
         )
+        print(job.filter.genre_classical)
         job.format.default = job.format.classical
         job.format.compilation = job.format.classical
         job.format.soundtrack = job.format.classical

--- a/audiorename/audiofile.py
+++ b/audiorename/audiofile.py
@@ -348,7 +348,6 @@ def do_job_on_audiofile(source, job=None):
             job.metadata_actions.remap_classical
         )
     elif source.meta.genre in ["Classical","Classical Instrumental","Classical Ballet","Classical Piano","Klassische Musik","Piano","Klavier"]:
-            job.metadata_actions.enrich_metadata:
         action.metadata(
             source,
             job.metadata_actions.enrich_metadata,

--- a/audiorename/audiofile.py
+++ b/audiorename/audiofile.py
@@ -347,7 +347,7 @@ def do_job_on_audiofile(source, job=None):
             job.metadata_actions.enrich_metadata,
             job.metadata_actions.remap_classical
         )
-    elif source.meta.genre in job.filter.genreclassical.split(","):
+    elif source.meta.genre in job.filter.genre_classical:
         action.metadata(
             source,
             job.metadata_actions.enrich_metadata,

--- a/audiorename/audiofile.py
+++ b/audiorename/audiofile.py
@@ -347,7 +347,7 @@ def do_job_on_audiofile(source, job=None):
             job.metadata_actions.enrich_metadata,
             job.metadata_actions.remap_classical
         )
-    elif source.meta.genre in job.filter.genre_classical:
+    elif source.meta.genre in job.filter.genre_classical.split(","):
         action.metadata(
             source,
             job.metadata_actions.enrich_metadata,

--- a/audiorename/audiofile.py
+++ b/audiorename/audiofile.py
@@ -339,6 +339,9 @@ def do_job_on_audiofile(source, job=None):
     ##
     # Metadata actions
     ##
+    
+    if source.meta.genre in ["Classical","Classical Instrumental","Classical Ballet","Classical Piano","Klassische Musik","Piano","Klavier"]:
+        job.metadata_actions.remap_classical=True
 
     if job.metadata_actions.remap_classical or \
             job.metadata_actions.enrich_metadata:

--- a/audiorename/audiofile.py
+++ b/audiorename/audiofile.py
@@ -347,7 +347,7 @@ def do_job_on_audiofile(source, job=None):
             job.metadata_actions.enrich_metadata,
             job.metadata_actions.remap_classical
         )
-    elif getattr(source.meta,"genre","").lower() in job.filter.genre_classical:
+    elif source.meta.genre is not None and getattr(source.meta,"genre","").lower() in job.filter.genre_classical:
         action.metadata(
             source,
             job.metadata_actions.enrich_metadata,

--- a/audiorename/audiofile.py
+++ b/audiorename/audiofile.py
@@ -340,10 +340,6 @@ def do_job_on_audiofile(source, job=None):
     # Metadata actions
     ##
     
-    if source.meta.genre in ["Classical","Classical Instrumental","Classical Ballet","Classical Piano","Klassische Musik","Piano","Klavier"]:
-        print(type(job.metadata_actions))
-        job.metadata_actions=job.metadata_actions._replace(remap_classical=True)
-
     if job.metadata_actions.remap_classical or \
             job.metadata_actions.enrich_metadata:
         action.metadata(
@@ -351,6 +347,30 @@ def do_job_on_audiofile(source, job=None):
             job.metadata_actions.enrich_metadata,
             job.metadata_actions.remap_classical
         )
+    elif source.meta.genre in ["Classical","Classical Instrumental","Classical Ballet","Classical Piano","Klassische Musik","Piano","Klavier"]:
+            job.metadata_actions.enrich_metadata:
+        action.metadata(
+            source,
+            job.metadata_actions.enrich_metadata,
+            True
+        )
+        job.format.default = '$ar_initial_composer/$ar_combined_composer/' \
+                '%shorten{$ar_combined_work_top,48}' \
+                '_[%shorten{$ar_classical_performer,32}]/' \
+                '${ar_combined_disctrack}_%shorten{$ar_classical_title,64}_' \
+                '%shorten{$acoustid_id,8}'
+
+        job.format.compilation = '$ar_initial_composer/$ar_combined_composer/' \
+                '%shorten{$ar_combined_work_top,48}' \
+                '_[%shorten{$ar_classical_performer,32}]/' \
+                '${ar_combined_disctrack}_%shorten{$ar_classical_title,64}_' \
+                '%shorten{$acoustid_id,8}'
+
+        job.format.soundtrack = '$ar_initial_composer/$ar_combined_composer/' \
+                '%shorten{$ar_combined_work_top,48}' \
+                '_[%shorten{$ar_classical_performer,32}]/' \
+                '${ar_combined_disctrack}_%shorten{$ar_classical_title,64}_' \
+                '%shorten{$acoustid_id,8}'
 
     ##
     # Rename action

--- a/audiorename/audiofile.py
+++ b/audiorename/audiofile.py
@@ -341,7 +341,7 @@ def do_job_on_audiofile(source, job=None):
     ##
     
     if source.meta.genre in ["Classical","Classical Instrumental","Classical Ballet","Classical Piano","Klassische Musik","Piano","Klavier"]:
-        job.metadata_actions.remap_classical=True
+        job.metadata_actions._replace(remap_classical=True)
 
     if job.metadata_actions.remap_classical or \
             job.metadata_actions.enrich_metadata:

--- a/audiorename/job.py
+++ b/audiorename/job.py
@@ -209,7 +209,7 @@ class Job(object):
             self._args.album_complete,
             self._args.album_min,
             self._args.extension.split(','),
-            self._args.genre_classical.lower().split(',')
+            list(filter(str.strip, self._args.genre_classical.lower().split(',')))
         )
 
     @property

--- a/audiorename/job.py
+++ b/audiorename/job.py
@@ -117,15 +117,19 @@ class Formats(object):
 
         if args.soundtrack:
             defaults.soundtrack = args.soundtrack
-
+        if args.format_classical:
+            defaults.classical = args.format_classical
+            
         if args.classical:
             self.default = defaults.classical
             self.compilation = defaults.classical
             self.soundtrack = defaults.classical
+            self.classical = defaults.classical
         else:
             self.default = defaults.default
             self.compilation = defaults.compilation
             self.soundtrack = defaults.soundtrack
+            self.classical = defaults.classical
 
 
 class RenameAction(object):

--- a/audiorename/job.py
+++ b/audiorename/job.py
@@ -119,6 +119,8 @@ class Formats(object):
             defaults.soundtrack = args.soundtrack
         if args.format_classical:
             defaults.classical = args.format_classical
+        else:
+            defaults.classical = args.classical
             
         if args.classical:
             self.default = defaults.classical

--- a/audiorename/job.py
+++ b/audiorename/job.py
@@ -201,13 +201,15 @@ class Job(object):
         Filter = namedtuple('Filter', [
             'album_complete',
             'album_min',
-            'extension'
+            'extension',
+            'genre_classical'
         ])
 
         return Filter(
             self._args.album_complete,
             self._args.album_min,
-            self._args.extension.split(',')
+            self._args.extension.split(','),
+            self._args.genre_classical.split(',')
         )
 
     @property

--- a/audiorename/job.py
+++ b/audiorename/job.py
@@ -209,7 +209,7 @@ class Job(object):
             self._args.album_complete,
             self._args.album_min,
             self._args.extension.split(','),
-            self._args.genre_classical.split(',')
+            self._args.genre_classical.lower().split(',')
         )
 
     @property

--- a/audiorename/meta.py
+++ b/audiorename/meta.py
@@ -443,7 +443,7 @@ class Meta(MediaFile):
                     str(safed[0]) + u': ' + \
                     str(safed[1]) + u'; '
 
-        self.comments = comments
+            self.comments = comments
 
 ###############################################################################
 # Class methods


### PR DESCRIPTION
The following features are added:
- the best format function was not working when the format was not in the list
- added argument to define a custom classical format additional to the common one
- added argument to define which genres are classical so it switches automatically between classical and non-classical in one run

Issues to discuss:
- The initiating of remap_classical on the fly by detecting[ the genre is not so perfect](https://github.com/Josef-Friedrich/audiorename/commit/f787f0a37b4b6a86408b544b0a8b68ffefb3f12c), because I was not able to change the namedtuple MetdataActions coming from the arguments
- ..