### PR TITLE
Add custom format string for classical

### DIFF
--- a/audiorename/args.py
+++ b/audiorename/args.py
@@ -122,6 +122,7 @@ class ArgsDefault():
     no_rename = False
     one_line = False
     remap_classical = False
+    format_classical = False
     shell_friendly = False
     soundtrack = False
     source = u'.'
@@ -401,7 +402,14 @@ def parse_args(argv):
         and functions to build the format string.',
         default=False
     )
-
+    # classical
+    format_strings.add_argument(
+        '--format-classical',
+        metavar='FORMAT_STRING',
+        help='Format string for classical audio file. Use metadata fields \
+        and functions to build the format string.',
+        default=False
+    )
 ###############################################################################
 # output
 ###############################################################################

--- a/audiorename/job.py
+++ b/audiorename/job.py
@@ -120,8 +120,6 @@ class Formats(object):
 
         if args.format_classical:
             defaults.classical = args.format_classical
-        else:
-            defaults.classical = args.classical
 
         if args.classical:
             self.default = defaults.classical

--- a/audiorename/job.py
+++ b/audiorename/job.py
@@ -118,6 +118,11 @@ class Formats(object):
         if args.soundtrack:
             defaults.soundtrack = args.soundtrack
 
+        if args.format_classical:
+            defaults.classical = args.format_classical
+        else:
+            defaults.classical = args.classical
+
         if args.classical:
             self.default = defaults.classical
             self.compilation = defaults.classical

--- a/test/test_args.py
+++ b/test/test_args.py
@@ -196,7 +196,8 @@ class TestArgsDefault(unittest.TestCase):
 
     def test_format_classical(self):
         self.assertEqual(self.args.format_classical, False)
-        self.assertEqual(self.args.format_classical, self.default.format_classical)
+        self.assertEqual(self.args.format_classical,
+                         self.default.format_classical)
 
     def test_job_info(self):
         self.assertEqual(self.args.job_info, False)

--- a/test/test_args.py
+++ b/test/test_args.py
@@ -194,6 +194,10 @@ class TestArgsDefault(unittest.TestCase):
         self.assertEqual(self.args.format, False)
         self.assertEqual(self.args.format, self.default.format)
 
+    def test_format_classical(self):
+        self.assertEqual(self.args.format_classical, False)
+        self.assertEqual(self.args.format_classical, self.default.format_classical)
+
     def test_job_info(self):
         self.assertEqual(self.args.job_info, False)
         self.assertEqual(self.args.job_info, self.default.job_info)


### PR DESCRIPTION
With `--format-classical` it is possible to use a custom format string when `using remap_classical`

Side note:
- The docs are not changed, I guess you generate them per a script?
- I added one test for default argument. Theoretically their should be also a test with a mp3 but not sure which you want to use and how this tests are working

Cool with the actions it seems to work now much better (even when I checked it with tox by my own)